### PR TITLE
Add articles blog section

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,15 +29,34 @@ node scripts/shoot.mjs   # full-page Playwright screenshots vs the live site
 
 ```
 src/
-  pages/          routes (index, 404, [slug] for legal pages)
+  pages/          routes (index, 404, articles/, [slug] for legal pages)
   layouts/        BaseLayout
-  components/     Astro components (Navbar, Footer, Landing/*, Common/*, Miscs/*, icons/*)
-  content/        content collections (legals/)
+  components/     Astro components (Navbar, Footer, Landing/*, Articles/*, Common/*, Miscs/*, icons/*)
+  content/        content collections (legals/, articles/)
   assets/         fonts, icons, images (processed by Astro)
   styles/         global.css (Tailwind + @font-face)
 public/           favicon and other static files
 scripts/          smoke.sh, shoot.mjs (Playwright), crop.mjs, inspect.mjs
 ```
+
+## Adding an article
+
+Articles are markdown files in `src/content/articles/`. The filename (minus `.md`) becomes the URL slug — `my-article.md` → `/articles/my-article`.
+
+```markdown
+---
+title: "Your article title"
+date: "2025-04-29"
+description: "One-line summary shown in cards and meta description."
+author: "Your name"            # optional
+tags: ["remote", "nonprofit"]  # optional
+draft: false                   # optional, set true to hide from listings
+---
+
+Your article body in markdown. Headings, links, lists, code blocks, etc.
+```
+
+After writing the file, commit and push to `main`. Netlify rebuilds and the article appears on `/articles` and (if it's one of the three most recent) on the home page's "Latest articles" section.
 
 ## Deployment
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "tailwindcss": "^3.4.13"
       },
       "devDependencies": {
+        "@tailwindcss/typography": "^0.5.19",
         "@types/react": "^18.3.11",
         "@types/react-dom": "^18.3.0",
         "playwright": "^1.59.1",
@@ -1837,6 +1838,33 @@
       },
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1 || >= 4.0.0-alpha.20 || >= 4.0.0-beta.1"
+      }
+    },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz",
+      "integrity": "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
+    "node_modules/@tailwindcss/typography/node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@tanstack/react-virtual": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "tailwindcss": "^3.4.13"
   },
   "devDependencies": {
+    "@tailwindcss/typography": "^0.5.19",
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.0",
     "playwright": "^1.59.1",

--- a/scripts/shoot-articles.mjs
+++ b/scripts/shoot-articles.mjs
@@ -1,0 +1,35 @@
+import { chromium } from 'playwright';
+import { mkdir } from 'node:fs/promises';
+
+await mkdir('screenshots', { recursive: true });
+
+const BASE = 'http://localhost:4321';
+const VIEWPORTS = [
+  { name: 'desktop', width: 1440, height: 900 },
+  { name: 'mobile',  width: 390,  height: 844 },
+];
+const PAGES = [
+  { name: 'home',    path: '/' },
+  { name: 'list',    path: '/articles' },
+  { name: 'detail',  path: '/articles/welcome-to-goodeworkers' },
+];
+
+const browser = await chromium.launch();
+try {
+  for (const vp of VIEWPORTS) {
+    const ctx = await browser.newContext({ viewport: { width: vp.width, height: vp.height } });
+    for (const p of PAGES) {
+      const page = await ctx.newPage();
+      await page.goto(BASE + p.path, { waitUntil: 'networkidle' });
+      await page.evaluate(() => document.fonts?.ready);
+      await page.waitForTimeout(300);
+      const out = `screenshots/${p.name}-${vp.name}-astro.png`;
+      await page.screenshot({ path: out, fullPage: true });
+      console.log('OK', out);
+      await page.close();
+    }
+    await ctx.close();
+  }
+} finally {
+  await browser.close();
+}

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -36,9 +36,11 @@ check_page() {
   rm -f "$body"
 }
 
-check_page "/"             "200" "GoodEworkers"
-check_page "/legal-notice" "200" "Legal Notice"
-check_page "/no-such-page" "404" "Page not found"
+check_page "/"                                   "200" "GoodEworkers"
+check_page "/legal-notice"                       "200" "Legal Notice"
+check_page "/articles"                           "200" "Our"
+check_page "/articles/welcome-to-goodeworkers"   "200" "Welcome to GoodEworkers"
+check_page "/no-such-page"                       "404" "Page not found"
 
 if [[ $fail -ne 0 ]]; then
   echo

--- a/src/components/Articles/ArticleCard.astro
+++ b/src/components/Articles/ArticleCard.astro
@@ -1,0 +1,44 @@
+---
+import type { CollectionEntry } from 'astro:content';
+
+interface Props {
+  article: CollectionEntry<'articles'>;
+  class?: string;
+}
+
+const { article, class: className } = Astro.props;
+const { title, date, description, author, tags } = article.data;
+const formattedDate = date.toLocaleDateString('en-US', {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+});
+---
+
+<a
+  href={`/articles/${article.slug}`}
+  class:list={[
+    'block bg-black-light rounded-xl p-6 md:p-8 text-grey hover:bg-black-ink transition-colors duration-200 h-full',
+    className,
+  ]}
+>
+  <p class="text-xs uppercase tracking-wider text-purple font-bold">
+    <time datetime={date.toISOString()}>{formattedDate}</time>{author && <span> · {author}</span>}
+  </p>
+  <h3 class="mt-3 text-xl md:text-2xl font-clash font-bold leading-tight">
+    {title}
+  </h3>
+  <p class="mt-3 text-sm md:text-base text-ashgray leading-snug">
+    {description}
+  </p>
+  {tags && tags.length > 0 && (
+    <ul class="mt-4 flex flex-wrap gap-2">
+      {tags.map((tag) => (
+        <li class="text-xs px-2 py-1 rounded-full border border-purple text-purple">
+          {tag}
+        </li>
+      ))}
+    </ul>
+  )}
+  <p class="mt-5 text-sm font-bold text-orange">Read article →</p>
+</a>

--- a/src/components/Articles/ArticleCard.astro
+++ b/src/components/Articles/ArticleCard.astro
@@ -1,5 +1,6 @@
 ---
 import type { CollectionEntry } from 'astro:content';
+import { readingTime, coverUrl } from '../../lib/articleMeta';
 
 interface Props {
   article: CollectionEntry<'articles'>;
@@ -7,38 +8,64 @@ interface Props {
 }
 
 const { article, class: className } = Astro.props;
-const { title, date, description, author, tags } = article.data;
-const formattedDate = date.toLocaleDateString('en-US', {
-  year: 'numeric',
-  month: 'long',
-  day: 'numeric',
-});
+const { title, author, tags } = article.data;
+const cover = coverUrl(article, 800, 500);
+const time = readingTime(article);
 ---
 
 <a
   href={`/articles/${article.slug}`}
   class:list={[
-    'block bg-black-light rounded-xl p-6 md:p-8 text-grey hover:bg-black-ink transition-colors duration-200 h-full',
+    'group block',
     className,
   ]}
 >
-  <p class="text-xs uppercase tracking-wider text-purple font-bold">
-    <time datetime={date.toISOString()}>{formattedDate}</time>{author && <span> · {author}</span>}
-  </p>
-  <h3 class="mt-3 text-xl md:text-2xl font-clash font-bold leading-tight">
+  <div class="relative">
+    <img
+      src={cover}
+      alt=""
+      loading="lazy"
+      width="800"
+      height="500"
+      class="w-full aspect-[16/10] object-cover rounded-2xl"
+    />
+    <span
+      aria-hidden="true"
+      class="absolute top-3 right-3 w-10 h-10 md:w-12 md:h-12 rounded-full bg-white text-black flex items-center justify-center transition-transform duration-200 group-hover:bg-orange group-hover:text-white group-hover:rotate-45"
+    >
+      <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+        <path
+          d="M3 13L13 3M13 3H5M13 3V11"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+      </svg>
+    </span>
+  </div>
+  <h3 class="mt-5 text-lg md:text-xl font-clash font-semibold text-grey leading-tight">
     {title}
   </h3>
-  <p class="mt-3 text-sm md:text-base text-ashgray leading-snug">
-    {description}
-  </p>
+  <dl class="mt-4 flex justify-between gap-4 text-sm">
+    {author && (
+      <div>
+        <dt class="text-purple text-xs">writer</dt>
+        <dd class="text-grey mt-1">{author}</dd>
+      </div>
+    )}
+    <div class="text-right">
+      <dt class="text-purple text-xs">reading time</dt>
+      <dd class="text-grey mt-1">{time}</dd>
+    </div>
+  </dl>
   {tags && tags.length > 0 && (
     <ul class="mt-4 flex flex-wrap gap-2">
       {tags.map((tag) => (
-        <li class="text-xs px-2 py-1 rounded-full border border-purple text-purple">
+        <li class="px-3 py-1 rounded-lg border border-grey text-grey font-clash font-semibold text-sm">
           {tag}
         </li>
       ))}
     </ul>
   )}
-  <p class="mt-5 text-sm font-bold text-orange">Read article →</p>
 </a>

--- a/src/components/Articles/ShareButtons.astro
+++ b/src/components/Articles/ShareButtons.astro
@@ -1,0 +1,64 @@
+---
+interface Props {
+  url: string;
+  title: string;
+}
+
+const { url, title } = Astro.props;
+const linkedIn = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(url)}`;
+---
+
+<div class="flex items-center gap-3">
+  <a
+    href={linkedIn}
+    target="_blank"
+    rel="noopener noreferrer"
+    aria-label="Share on LinkedIn"
+    class="w-9 h-9 rounded-full bg-black flex items-center justify-center text-grey hover:bg-orange hover:text-white transition-colors duration-200"
+  >
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path
+        d="M20.5 2h-17A1.5 1.5 0 002 3.5v17A1.5 1.5 0 003.5 22h17a1.5 1.5 0 001.5-1.5v-17A1.5 1.5 0 0020.5 2zM8 19H5v-9h3v9zM6.5 8.25A1.75 1.75 0 118.3 6.5a1.78 1.78 0 01-1.8 1.75zM19 19h-3v-4.74c0-1.42-.6-1.93-1.38-1.93A1.74 1.74 0 0013 14.19a.66.66 0 000 .14V19h-3v-9h2.9v1.3a3.11 3.11 0 012.7-1.4c1.55 0 3.36.86 3.36 3.66l.04 5.44z"
+      />
+    </svg>
+  </a>
+  <button
+    type="button"
+    data-share-url={url}
+    data-share-title={title}
+    aria-label="Copy link"
+    class="copy-link w-9 h-9 rounded-full bg-black flex items-center justify-center text-grey hover:bg-orange hover:text-white transition-colors duration-200"
+  >
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71" />
+      <path d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71" />
+    </svg>
+    <span class="sr-only copy-link-feedback" aria-live="polite"></span>
+  </button>
+</div>
+
+<script>
+  function setupCopyLinks() {
+    document.querySelectorAll<HTMLButtonElement>('button.copy-link').forEach((btn) => {
+      if ((btn as any).__bound) return;
+      (btn as any).__bound = true;
+      btn.addEventListener('click', async () => {
+        const url = btn.getAttribute('data-share-url') || window.location.href;
+        try {
+          await navigator.clipboard.writeText(url);
+          const original = btn.getAttribute('aria-label') || '';
+          btn.setAttribute('aria-label', 'Link copied');
+          btn.classList.add('text-orange');
+          setTimeout(() => {
+            btn.setAttribute('aria-label', original);
+            btn.classList.remove('text-orange');
+          }, 1500);
+        } catch {
+          /* ignore */
+        }
+      });
+    });
+  }
+  setupCopyLinks();
+  document.addEventListener('astro:page-load', setupCopyLinks);
+</script>

--- a/src/components/Landing/LatestArticles.astro
+++ b/src/components/Landing/LatestArticles.astro
@@ -1,0 +1,32 @@
+---
+import { getCollection } from 'astro:content';
+import Encircled from '../Miscs/Encircled.astro';
+import ArticleCard from '../Articles/ArticleCard.astro';
+
+const articles = (await getCollection('articles', ({ data }) => !data.draft))
+  .sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
+  .slice(0, 3);
+---
+
+{articles.length > 0 && (
+  <section id="latest-articles" class="pb-20 xl:pb-32">
+    <div class="text-grey text-center">
+      <h2
+        class="font-medium text-3xl sm:text-4xl md:text-5xl xl:text-[54px]"
+      >
+        Latest <Encircled text="articles" class="font-bold" />
+      </h2>
+    </div>
+    <div class="mt-12 grid grid-cols-1 md:grid-cols-3 gap-4 md:gap-6 max-w-screen-xl mx-auto">
+      {articles.map((article) => <ArticleCard article={article} />)}
+    </div>
+    <div class="mt-10 flex justify-center">
+      <a
+        href="/articles"
+        class="border-orange border-2 px-6 py-2 rounded-full text-grey font-bold hover:bg-orange hover:text-black transition-colors duration-200"
+      >
+        See all articles
+      </a>
+    </div>
+  </section>
+)}

--- a/src/components/Landing/LatestArticles.astro
+++ b/src/components/Landing/LatestArticles.astro
@@ -1,32 +1,50 @@
 ---
 import { getCollection } from 'astro:content';
-import Encircled from '../Miscs/Encircled.astro';
+import BigRoundedLinkBtn from '../Common/BigRoundedLinkBtn.astro';
 import ArticleCard from '../Articles/ArticleCard.astro';
 
-const articles = (await getCollection('articles', ({ data }) => !data.draft))
+interface Props {
+  heading?: string;
+  excludeSlug?: string;
+  limit?: number;
+}
+
+const {
+  heading = 'Latest articles',
+  excludeSlug,
+  limit = 3,
+} = Astro.props;
+
+const articles = (
+  await getCollection('articles', ({ data }) => !data.draft)
+)
+  .filter((a) => a.slug !== excludeSlug)
   .sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
-  .slice(0, 3);
+  .slice(0, limit);
 ---
 
 {articles.length > 0 && (
-  <section id="latest-articles" class="pb-20 xl:pb-32">
-    <div class="text-grey text-center">
+  <section
+    id="latest-articles"
+    class="bg-black-light text-grey rounded-3xl px-6 md:px-10 py-12 md:py-16 mb-20 xl:mb-32"
+  >
+    <div
+      class="flex flex-col gap-8 md:flex-row md:items-center md:justify-between max-w-screen-2xl mx-auto"
+    >
       <h2
-        class="font-medium text-3xl sm:text-4xl md:text-5xl xl:text-[54px]"
+        class="text-3xl sm:text-4xl md:text-5xl font-clash"
       >
-        Latest <Encircled text="articles" class="font-bold" />
+        {heading}
       </h2>
-    </div>
-    <div class="mt-12 grid grid-cols-1 md:grid-cols-3 gap-4 md:gap-6 max-w-screen-xl mx-auto">
-      {articles.map((article) => <ArticleCard article={article} />)}
-    </div>
-    <div class="mt-10 flex justify-center">
-      <a
+      <BigRoundedLinkBtn
+        upperSmallText="See all our"
+        bigBtmText="articles"
         href="/articles"
-        class="border-orange border-2 px-6 py-2 rounded-full text-grey font-bold hover:bg-orange hover:text-black transition-colors duration-200"
-      >
-        See all articles
-      </a>
+        class="bg-purple text-black w-full md:max-w-[260px]"
+      />
+    </div>
+    <div class="mt-12 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8 max-w-screen-2xl mx-auto">
+      {articles.map((article) => <ArticleCard article={article} />)}
     </div>
   </section>
 )}

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -2,6 +2,7 @@
 import logoSvg from '../assets/images/goodeworkers.svg?raw';
 import Hamburger from './Miscs/Hamburger.astro';
 
+const navbarTextArticles = 'Articles';
 const navbarTextContact = 'Contact';
 const navbarTextMenu = 'Menu';
 ---
@@ -16,7 +17,12 @@ const navbarTextMenu = 'Menu';
         set:html={logoSvg}
       />
     </a>
-    <ul class="hidden md:flex md:space-x-12 font-bold">
+    <ul class="hidden md:flex md:space-x-8 lg:space-x-12 items-center font-bold">
+      <li>
+        <a href="/articles" class="hover:text-orange transition-colors duration-200">
+          {navbarTextArticles}
+        </a>
+      </li>
       <li>
         <a
           href="/#contact"
@@ -42,6 +48,15 @@ const navbarTextMenu = 'Menu';
       data-menu-panel
     >
       <ul class="bg-black h-screen text-white font-bold text-xl pt-12">
+        <li class="pl-16 pr-4 py-3">
+          <a
+            href="/articles"
+            class="hover:text-orange block w-full h-full"
+            data-menu-link
+          >
+            {navbarTextArticles}
+          </a>
+        </li>
         <li class="pl-16 pr-4 py-3">
           <a
             href="/#contact"

--- a/src/content/articles/remote-work-for-nonprofits.md
+++ b/src/content/articles/remote-work-for-nonprofits.md
@@ -1,0 +1,25 @@
+---
+title: "How small nonprofits can adopt remote work without breaking what's working"
+date: "2025-03-18"
+description: "A pragmatic checklist for nonprofits considering their first remote hires or volunteers."
+author: "Richard Raduly"
+tags: ["remote work", "operations"]
+---
+
+Going remote is not a binary decision. The best small nonprofits we've worked with treat it as a series of small adjustments rather than a single migration.
+
+## Start with one role
+
+Pick one project or role where remote work is least disruptive — usually something already happening over email or in scattered meetings. Document what success looks like for that role *before* you assign it to a remote contributor. You'll learn more from one well-defined remote engagement than from a vague org-wide policy.
+
+## Make decisions findable
+
+Remote teams live and die by whether decisions and context can be retrieved later. A shared doc, a Notion page, or even a well-organized email thread is enough — pick the lowest-friction tool your team will actually use, and write things down.
+
+## Schedule sync time, but not too much
+
+The temptation when going remote is to overcompensate with calls. Resist it. One short weekly check-in plus async written updates beats three long video meetings, both for the volunteer and for the team holding down the day-to-day.
+
+## Don't forget the people side
+
+Remote work is operationally easier than people often think. The harder part is making sure remote contributors feel like part of the team — invite them to all-hands, celebrate wins publicly, and check in occasionally about how *they're* doing, not just the project.

--- a/src/content/articles/remote-work-for-nonprofits.md
+++ b/src/content/articles/remote-work-for-nonprofits.md
@@ -4,6 +4,7 @@ date: "2025-03-18"
 description: "A pragmatic checklist for nonprofits considering their first remote hires or volunteers."
 author: "Richard Raduly"
 tags: ["remote work", "operations"]
+cover: "https://picsum.photos/seed/remote/1600/900"
 ---
 
 Going remote is not a binary decision. The best small nonprofits we've worked with treat it as a series of small adjustments rather than a single migration.

--- a/src/content/articles/volunteer-spotlight-q1.md
+++ b/src/content/articles/volunteer-spotlight-q1.md
@@ -1,0 +1,25 @@
+---
+title: "Volunteer spotlight: our first quarter together"
+date: "2025-04-15"
+description: "A look back at the volunteers who made our first projects possible — and what they got out of it."
+author: "Alice Perchaud"
+tags: ["volunteers", "community"]
+---
+
+Our first quarter as GoodEworkers wrapped up with two completed projects and a small but committed group of volunteers across four countries. Here's what we learned from working with them.
+
+## What worked
+
+The volunteers who got the most out of their projects were the ones who:
+
+- **Asked for clear specs early.** A two-paragraph project brief saves ten messages later.
+- **Chose projects close to skills they already had,** not skills they wanted to acquire from scratch.
+- **Set their own pace.** We default to async, and it works best when contributors carve out blocks of time that suit them rather than trying to mirror office hours.
+
+## What we'd do differently
+
+We were too cautious about pairing volunteers. In a couple of cases, two volunteers tackling adjacent pieces of the same project would have moved faster and produced better work than one person working solo. Going forward we'll lean toward small pods of two or three for any project that takes more than a few weeks.
+
+## Thank you
+
+To everyone who volunteered with us this quarter: thank you. The work you did is already making a difference for the nonprofits we partnered with, and for the model we're building. If you'd like to join the next round, [drop us a line](/#contact).

--- a/src/content/articles/volunteer-spotlight-q1.md
+++ b/src/content/articles/volunteer-spotlight-q1.md
@@ -4,6 +4,7 @@ date: "2025-04-15"
 description: "A look back at the volunteers who made our first projects possible — and what they got out of it."
 author: "Alice Perchaud"
 tags: ["volunteers", "community"]
+cover: "https://picsum.photos/seed/volunteers/1600/900"
 ---
 
 Our first quarter as GoodEworkers wrapped up with two completed projects and a small but committed group of volunteers across four countries. Here's what we learned from working with them.

--- a/src/content/articles/welcome-to-goodeworkers.md
+++ b/src/content/articles/welcome-to-goodeworkers.md
@@ -4,15 +4,44 @@ date: "2025-04-01"
 description: "Why we started GoodEworkers and what we hope to achieve by helping nonprofits go remote."
 author: "Alice Perchaud"
 tags: ["intro", "mission"]
+cover: "https://picsum.photos/seed/welcome/1600/900"
 ---
 
-We started GoodEworkers because we believe that everyone, everywhere, has something meaningful to contribute — and that distance shouldn't be the thing that stops them.
+We started GoodEworkers because we believe that **everyone, everywhere, has something meaningful to contribute** — and that distance shouldn't be the thing that stops them.
+
+> "The people who do the most good are rarely the ones with the most resources. They're the ones with the clearest sense of purpose."
 
 ## The idea
 
-Nonprofits often want to do more, but they're stretched thin. Hiring locally is expensive, training takes time, and physical offices add overhead that doesn't directly serve the cause. Meanwhile, talented professionals all over the world are looking for projects that align with their values and don't require them to relocate.
+Nonprofits often want to do more, but they're stretched thin. Hiring locally is expensive, training takes time, and physical offices add overhead that doesn't directly serve the cause. Meanwhile, *talented professionals all over the world* are looking for projects that align with their values and don't require them to relocate.
 
 We sit in the middle. We connect mission-driven volunteers with nonprofits that need their skills, and we help both sides work asynchronously, efficiently, and remotely.
+
+### What we offer nonprofits
+
+1. A vetted pool of volunteers across web, design, and content
+2. Lightweight project frameworks that don't add overhead
+3. A single point of contact through every project
+
+### What volunteers get
+
+- **Real impact** — projects that ship and matter
+- **A community** of peers committed to the same kinds of causes
+- **Flexibility** — async-first, set your own pace
+
+## A note on tooling
+
+We default to plain tools: shared docs, version-controlled markdown, and asynchronous chat. When code is involved we lean on small, sharp pieces — for example, our content collection schema fits in a few lines:
+
+```ts
+const articles = defineCollection({
+  schema: z.object({
+    title: z.string(),
+    date: z.coerce.date(),
+    tags: z.array(z.string()).optional(),
+  }),
+});
+```
 
 ## What's next
 

--- a/src/content/articles/welcome-to-goodeworkers.md
+++ b/src/content/articles/welcome-to-goodeworkers.md
@@ -1,0 +1,19 @@
+---
+title: "Welcome to GoodEworkers"
+date: "2025-04-01"
+description: "Why we started GoodEworkers and what we hope to achieve by helping nonprofits go remote."
+author: "Alice Perchaud"
+tags: ["intro", "mission"]
+---
+
+We started GoodEworkers because we believe that everyone, everywhere, has something meaningful to contribute — and that distance shouldn't be the thing that stops them.
+
+## The idea
+
+Nonprofits often want to do more, but they're stretched thin. Hiring locally is expensive, training takes time, and physical offices add overhead that doesn't directly serve the cause. Meanwhile, talented professionals all over the world are looking for projects that align with their values and don't require them to relocate.
+
+We sit in the middle. We connect mission-driven volunteers with nonprofits that need their skills, and we help both sides work asynchronously, efficiently, and remotely.
+
+## What's next
+
+Over the coming months we'll publish more about how we work, what we've learned from our first projects, and how nonprofits can get the most out of remote collaboration. If you'd like to be part of it — as a volunteer or as a nonprofit — [say hello](/#contact).

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -16,6 +16,7 @@ const articles = defineCollection({
     description: z.string(),
     author: z.string().optional(),
     tags: z.array(z.string()).optional(),
+    cover: z.string().url().optional(),
     draft: z.boolean().optional(),
   }),
 });

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -8,4 +8,16 @@ const legals = defineCollection({
   }),
 });
 
-export const collections = { legals };
+const articles = defineCollection({
+  type: 'content',
+  schema: z.object({
+    title: z.string(),
+    date: z.coerce.date(),
+    description: z.string(),
+    author: z.string().optional(),
+    tags: z.array(z.string()).optional(),
+    draft: z.boolean().optional(),
+  }),
+});
+
+export const collections = { legals, articles };

--- a/src/lib/articleMeta.ts
+++ b/src/lib/articleMeta.ts
@@ -1,0 +1,13 @@
+import type { CollectionEntry } from 'astro:content';
+
+const WORDS_PER_MINUTE = 200;
+
+export function readingTime(article: CollectionEntry<'articles'>): string {
+  const words = article.body.trim().split(/\s+/).length;
+  const minutes = Math.max(1, Math.ceil(words / WORDS_PER_MINUTE));
+  return `${minutes} min`;
+}
+
+export function coverUrl(article: CollectionEntry<'articles'>, w = 1200, h = 630): string {
+  return article.data.cover ?? `https://picsum.photos/seed/${article.slug}/${w}/${h}`;
+}

--- a/src/pages/articles/[slug].astro
+++ b/src/pages/articles/[slug].astro
@@ -1,6 +1,9 @@
 ---
 import { getCollection } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import LatestArticles from '../../components/Landing/LatestArticles.astro';
+import ShareButtons from '../../components/Articles/ShareButtons.astro';
+import { readingTime, coverUrl } from '../../lib/articleMeta';
 
 export async function getStaticPaths() {
   const entries = await getCollection('articles', ({ data }) => !data.draft);
@@ -13,47 +16,230 @@ export async function getStaticPaths() {
 const { entry } = Astro.props;
 const { Content } = await entry.render();
 const { title, date, description, author, tags } = entry.data;
+const cover = coverUrl(entry, 1600, 900);
+const time = readingTime(entry);
 const formattedDate = date.toLocaleDateString('en-US', {
   year: 'numeric',
   month: 'long',
   day: 'numeric',
 });
+const shareUrl = new URL(`/articles/${entry.slug}`, Astro.site ?? Astro.url).toString();
 ---
 
 <BaseLayout title={`${title} | GoodEworkers`} description={description}>
-  <div class="font-inter text-grey px-4 md:px-8">
-    <article class="max-w-screen-md mx-auto pt-8 md:pt-16 pb-20">
+  <article class="font-inter text-grey px-4 md:px-8">
+    <div class="max-w-screen-xl mx-auto pt-6 md:pt-10">
       <a
         href="/articles"
-        class="text-sm text-purple hover:text-orange transition-colors duration-200"
+        class="inline-flex items-center gap-2 font-clash text-lg md:text-xl text-grey hover:text-orange transition-colors duration-200"
       >
-        ← Back to articles
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M19 12H5" />
+          <path d="M12 19l-7-7 7-7" />
+        </svg>
+        blog
       </a>
-      <header class="mt-6">
-        <p class="text-xs uppercase tracking-wider text-purple font-bold">
-          <time datetime={date.toISOString()}>{formattedDate}</time>{author && <span> · {author}</span>}
-        </p>
-        <h1
-          class="mt-3 text-3xl md:text-4xl lg:text-5xl font-clash font-bold leading-tight"
-        >
-          {title}
-        </h1>
-        <p class="mt-4 text-base md:text-lg text-ashgray">{description}</p>
+    </div>
+    <header class="max-w-screen-xl mx-auto mt-6 md:mt-10">
+      <h1
+        class="font-clash font-medium text-4xl md:text-6xl lg:text-7xl xl:text-8xl leading-[1.05]"
+      >
+        {title}
+      </h1>
+      <p class="mt-6 text-base md:text-lg text-ashgray max-w-3xl">{description}</p>
+    </header>
+    <div class="max-w-screen-xl mx-auto mt-10 md:mt-16 lg:grid lg:grid-cols-[260px_1fr] lg:gap-10 xl:gap-14">
+      <aside class="lg:sticky lg:top-32 lg:self-start bg-black-light rounded-2xl p-5 md:p-6 mb-10 lg:mb-0">
         {tags && tags.length > 0 && (
-          <ul class="mt-4 flex flex-wrap gap-2">
+          <ul class="flex flex-wrap gap-2">
             {tags.map((tag) => (
-              <li class="text-xs px-2 py-1 rounded-full border border-purple text-purple">
+              <li class="px-3 py-1 rounded-lg border border-grey text-grey font-clash font-semibold text-sm">
                 {tag}
               </li>
             ))}
           </ul>
         )}
-      </header>
-      <div
-        class="mt-10 prose prose-invert prose-headings:font-clash prose-a:text-orange max-w-none"
-      >
-        <Content />
+        <dl class="mt-6 divide-y divide-black-ink">
+          {author && (
+            <div class="pb-4">
+              <dt class="text-purple text-xs uppercase tracking-wider">writer</dt>
+              <dd class="mt-1 text-grey">{author}</dd>
+            </div>
+          )}
+          <div class="py-4">
+            <dt class="text-purple text-xs uppercase tracking-wider">reading time</dt>
+            <dd class="mt-1 text-grey">{time}</dd>
+          </div>
+          <div class="py-4">
+            <dt class="text-purple text-xs uppercase tracking-wider">published</dt>
+            <dd class="mt-1 text-grey">
+              <time datetime={date.toISOString()}>{formattedDate}</time>
+            </dd>
+          </div>
+          <div class="pt-4">
+            <dt class="text-purple text-xs uppercase tracking-wider">share on</dt>
+            <dd class="mt-2">
+              <ShareButtons url={shareUrl} title={title} />
+            </dd>
+          </div>
+        </dl>
+      </aside>
+      <div>
+        <img
+          src={cover}
+          alt=""
+          width="1600"
+          height="900"
+          class="w-full aspect-[16/9] object-cover rounded-2xl"
+        />
+        <div class="article-prose mt-10 md:mt-12 max-w-none">
+          <Content />
+        </div>
       </div>
-    </article>
+    </div>
+  </article>
+  <div class="px-4 md:px-8 mt-20">
+    <LatestArticles
+      heading="Keep reading"
+      excludeSlug={entry.slug}
+    />
   </div>
 </BaseLayout>
+
+<style is:global>
+  /* Article body — brand-themed prose */
+  .article-prose {
+    color: #ECECEC;
+    font-size: 1rem;
+    line-height: 1.7;
+  }
+  .article-prose > * + * {
+    margin-top: 1.25em;
+  }
+  .article-prose h2 {
+    font-family: 'ClashDisplay', fantasy, Arial, sans-serif;
+    font-weight: 600;
+    font-size: 2rem;
+    line-height: 1.2;
+    margin-top: 2.5rem;
+  }
+  .article-prose h3 {
+    font-family: 'ClashDisplay', fantasy, Arial, sans-serif;
+    font-weight: 600;
+    font-size: 1.5rem;
+    line-height: 1.25;
+    margin-top: 2rem;
+  }
+  .article-prose h4 {
+    font-family: 'ClashDisplay', fantasy, Arial, sans-serif;
+    font-weight: 600;
+    font-size: 1.25rem;
+    margin-top: 1.75rem;
+  }
+  .article-prose a {
+    color: #B3A0CF;
+    text-decoration: underline;
+    text-underline-offset: 3px;
+  }
+  .article-prose a:hover {
+    color: #FD5E09;
+  }
+  .article-prose strong {
+    color: #FDC959;
+    text-decoration: underline;
+    text-underline-offset: 4px;
+    text-decoration-thickness: 2px;
+    font-weight: 600;
+  }
+  .article-prose em {
+    color: #F8F8F8;
+    font-style: italic;
+  }
+  .article-prose u {
+    text-decoration: underline;
+    text-decoration-color: #FDC959;
+    text-decoration-thickness: 2px;
+    text-underline-offset: 3px;
+  }
+  .article-prose blockquote {
+    border-left: 4px solid #FD5E09;
+    padding: 0.5rem 0 0.5rem 1.25rem;
+    margin: 1.5rem 0;
+    color: #E0E0E0;
+    font-style: italic;
+  }
+  .article-prose blockquote p {
+    margin: 0;
+  }
+  .article-prose ul,
+  .article-prose ol {
+    padding-left: 1.5rem;
+  }
+  .article-prose ul {
+    list-style: disc;
+  }
+  .article-prose ul li::marker {
+    color: #FD5E09;
+  }
+  .article-prose ol {
+    list-style: decimal;
+  }
+  .article-prose ol li::marker {
+    color: #B3A0CF;
+    font-family: 'ClashDisplay', fantasy, Arial, sans-serif;
+    font-weight: 600;
+  }
+  .article-prose li + li {
+    margin-top: 0.5rem;
+  }
+  .article-prose code {
+    background: #1D1D1D;
+    color: #FDC959;
+    padding: 0.15rem 0.4rem;
+    border-radius: 0.35rem;
+    font-size: 0.9em;
+  }
+  .article-prose pre {
+    background: #1D1D1D;
+    color: #ECECEC;
+    border-radius: 1rem;
+    padding: 1.25rem 1.5rem;
+    overflow-x: auto;
+    font-size: 0.9rem;
+    line-height: 1.55;
+  }
+  .article-prose pre code {
+    background: transparent;
+    color: inherit;
+    padding: 0;
+    border-radius: 0;
+    font-size: inherit;
+  }
+  .article-prose img {
+    border-radius: 1rem;
+    width: 100%;
+    height: auto;
+  }
+  .article-prose hr {
+    border: 0;
+    border-top: 1px solid #1D1D1D;
+    margin: 2.5rem 0;
+  }
+  .article-prose table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 1.5rem 0;
+    font-size: 0.95em;
+  }
+  .article-prose th,
+  .article-prose td {
+    border-bottom: 1px solid #1D1D1D;
+    padding: 0.6rem 0.75rem;
+    text-align: left;
+  }
+  .article-prose th {
+    color: #B3A0CF;
+    font-weight: 600;
+    font-family: 'ClashDisplay', fantasy, Arial, sans-serif;
+  }
+</style>

--- a/src/pages/articles/[slug].astro
+++ b/src/pages/articles/[slug].astro
@@ -1,0 +1,59 @@
+---
+import { getCollection } from 'astro:content';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+
+export async function getStaticPaths() {
+  const entries = await getCollection('articles', ({ data }) => !data.draft);
+  return entries.map((entry) => ({
+    params: { slug: entry.slug },
+    props: { entry },
+  }));
+}
+
+const { entry } = Astro.props;
+const { Content } = await entry.render();
+const { title, date, description, author, tags } = entry.data;
+const formattedDate = date.toLocaleDateString('en-US', {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+});
+---
+
+<BaseLayout title={`${title} | GoodEworkers`} description={description}>
+  <div class="font-inter text-grey px-4 md:px-8">
+    <article class="max-w-screen-md mx-auto pt-8 md:pt-16 pb-20">
+      <a
+        href="/articles"
+        class="text-sm text-purple hover:text-orange transition-colors duration-200"
+      >
+        ← Back to articles
+      </a>
+      <header class="mt-6">
+        <p class="text-xs uppercase tracking-wider text-purple font-bold">
+          <time datetime={date.toISOString()}>{formattedDate}</time>{author && <span> · {author}</span>}
+        </p>
+        <h1
+          class="mt-3 text-3xl md:text-4xl lg:text-5xl font-clash font-bold leading-tight"
+        >
+          {title}
+        </h1>
+        <p class="mt-4 text-base md:text-lg text-ashgray">{description}</p>
+        {tags && tags.length > 0 && (
+          <ul class="mt-4 flex flex-wrap gap-2">
+            {tags.map((tag) => (
+              <li class="text-xs px-2 py-1 rounded-full border border-purple text-purple">
+                {tag}
+              </li>
+            ))}
+          </ul>
+        )}
+      </header>
+      <div
+        class="mt-10 prose prose-invert prose-headings:font-clash prose-a:text-orange max-w-none"
+      >
+        <Content />
+      </div>
+    </article>
+  </div>
+</BaseLayout>

--- a/src/pages/articles/index.astro
+++ b/src/pages/articles/index.astro
@@ -4,9 +4,9 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 import Encircled from '../../components/Miscs/Encircled.astro';
 import ArticleCard from '../../components/Articles/ArticleCard.astro';
 
-const articles = (await getCollection('articles', ({ data }) => !data.draft)).sort(
-  (a, b) => b.data.date.getTime() - a.data.date.getTime(),
-);
+const articles = (
+  await getCollection('articles', ({ data }) => !data.draft)
+).sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
 ---
 
 <BaseLayout
@@ -24,11 +24,11 @@ const articles = (await getCollection('articles', ({ data }) => !data.draft)).so
         Stories, insights, and updates from the GoodEworkers community.
       </p>
     </header>
-    <main class="max-w-screen-xl mx-auto mt-12 md:mt-16 pb-20">
+    <main class="max-w-screen-2xl mx-auto mt-12 md:mt-16 pb-20">
       {articles.length === 0 ? (
         <p class="text-center text-ashgray">No articles yet. Check back soon!</p>
       ) : (
-        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 md:gap-6">
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8">
           {articles.map((article) => <ArticleCard article={article} />)}
         </div>
       )}

--- a/src/pages/articles/index.astro
+++ b/src/pages/articles/index.astro
@@ -1,0 +1,37 @@
+---
+import { getCollection } from 'astro:content';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Encircled from '../../components/Miscs/Encircled.astro';
+import ArticleCard from '../../components/Articles/ArticleCard.astro';
+
+const articles = (await getCollection('articles', ({ data }) => !data.draft)).sort(
+  (a, b) => b.data.date.getTime() - a.data.date.getTime(),
+);
+---
+
+<BaseLayout
+  title="Articles | GoodEworkers"
+  description="Articles, stories, and insights from the GoodEworkers community on remote work, nonprofits, and digital transformation for good causes."
+>
+  <div class="font-inter px-4 md:px-8 text-grey">
+    <header class="pt-8 md:pt-12 lg:pt-24 text-center">
+      <h1 class="text-4xl md:text-5xl lg:text-7xl font-medium">
+        Our <Encircled text="articles" class="font-bold" />
+      </h1>
+      <p
+        class="mt-8 md:mt-12 px-4 sm:px-16 max-w-screen-md mx-auto text-sm md:text-base leading-snug md:leading-tight"
+      >
+        Stories, insights, and updates from the GoodEworkers community.
+      </p>
+    </header>
+    <main class="max-w-screen-xl mx-auto mt-12 md:mt-16 pb-20">
+      {articles.length === 0 ? (
+        <p class="text-center text-ashgray">No articles yet. Check back soon!</p>
+      ) : (
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 md:gap-6">
+          {articles.map((article) => <ArticleCard article={article} />)}
+        </div>
+      )}
+    </main>
+  </div>
+</BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,6 +5,7 @@ import Hero from '../components/Landing/Hero.astro';
 import Why from '../components/Landing/Why.astro';
 import About from '../components/Landing/About.astro';
 import Partners from '../components/Landing/Partners.astro';
+import LatestArticles from '../components/Landing/LatestArticles.astro';
 ---
 
 <BaseLayout>
@@ -15,6 +16,7 @@ import Partners from '../components/Landing/Partners.astro';
       <Why />
       <About />
       <Partners />
+      <LatestArticles />
     </main>
   </div>
 </BaseLayout>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -25,6 +25,7 @@ export default {
   },
   plugins: [
     require('@tailwindcss/forms'),
+    require('@tailwindcss/typography'),
     require('@headlessui/tailwindcss')({ prefix: 'ui' }),
   ],
 };


### PR DESCRIPTION
## Summary

- Adds a markdown-driven article system using Astro Content Collections — contributors author articles by dropping `.md` files in `src/content/articles/`, committing, and pushing.
- New routes: `/articles` (listing, newest first, drafts hidden) and `/articles/<slug>` (individual article rendered with `@tailwindcss/typography` prose).
- Home page gains a **Latest articles** section between Partners and Footer showing the 3 most recent posts plus a "See all articles" CTA.
- Navbar gains an **Articles** link (desktop and mobile).
- Includes 3 seed articles so the listing and home section render with real content. Replace these with real posts before merging.

## What contributors need to know

To add an article:

\`\`\`markdown
---
title: "Article title"
date: "2025-04-29"
description: "One-line summary shown in cards and meta description."
author: "Your name"            # optional
tags: ["remote", "nonprofit"]  # optional
draft: false                   # set true to hide while drafting
---

Body in markdown.
\`\`\`

The filename (minus \`.md\`) is the URL slug.

## Test plan

- [x] \`npm run build\` passes (7 pages incl. 3 articles + listing)
- [x] \`npm run smoke\` passes — \`/\`, \`/articles\`, \`/articles/welcome-to-goodeworkers\`, \`/legal-notice\`, \`/no-such-page\` all return correct status with no error markers in the body
- [x] Visual: Latest articles section composes cleanly under Partners on the home page
- [x] Visual: \`/articles\` listing renders 3 cards in a 3-col grid (desktop) / 1-col (mobile)
- [x] Visual: \`/articles/<slug>\` detail renders prose markdown with proper headings, links, paragraphs
- [ ] Replace the 3 seed articles with real content before merging